### PR TITLE
New moneyin tests

### DIFF
--- a/MercadoPagoSDKExampleSwift/Model/Configurations.swift
+++ b/MercadoPagoSDKExampleSwift/Model/Configurations.swift
@@ -19,4 +19,5 @@ struct Configurations {
     var accountMoney: Bool
     var secondFactor: Bool
     var payerInfo: Bool
+    var localizedTexts: Bool
 }

--- a/MercadoPagoSDKExampleSwift/View Cotrollers/CheckoutOptionsViewController.swift
+++ b/MercadoPagoSDKExampleSwift/View Cotrollers/CheckoutOptionsViewController.swift
@@ -12,7 +12,7 @@ import PXAccountMoneyPlugin
 
 class CheckoutOptionsViewController: UIViewController, ConfigurationManager {
 
-    var configurations: Configurations = Configurations(comisiones: false,descuento: false,tope: false,paymentPlugin: false, paymentPluginViewController : false, discountNotAvailable: false,maxRedeemPerUser: 0,accountMoney: false, secondFactor: false, payerInfo: false)
+    var configurations: Configurations = Configurations(comisiones: false,descuento: false,tope: false,paymentPlugin: false, paymentPluginViewController : false, discountNotAvailable: false,maxRedeemPerUser: 0,accountMoney: false, secondFactor: false, payerInfo: false, localizedTexts: false)
 
     var addCardFlow : AddCardFlow?
 
@@ -190,7 +190,7 @@ class CheckoutOptionsViewController: UIViewController, ConfigurationManager {
             }
         }
 
-        let builder =  getBuilder(publicKey: publicKey, prefId: prefId, accessToken:accessToken, cardId: cardId, paymentConfig: paymentPref, setPayer: configurations.payerInfo)
+        let builder =  getBuilder(publicKey: publicKey, prefId: prefId, accessToken:accessToken, cardId: cardId, paymentConfig: paymentPref, setPayer: configurations.payerInfo, localizedTexts: configurations.localizedTexts)
         MercadoPagoCheckout.init(builder:builder).start(navigationController: self.navigationController!)
     }
 
@@ -202,7 +202,7 @@ class CheckoutOptionsViewController: UIViewController, ConfigurationManager {
         self.addCardFlow?.start()
     }
 
-    func getBuilder(publicKey: String, prefId: String, accessToken: String?,  cardId: String?, paymentConfig: PXPaymentConfiguration?, setPayer: Bool) -> MercadoPagoCheckoutBuilder {
+    func getBuilder(publicKey: String, prefId: String, accessToken: String?,  cardId: String?, paymentConfig: PXPaymentConfiguration?, setPayer: Bool, localizedTexts: Bool) -> MercadoPagoCheckoutBuilder {
         var builder : MercadoPagoCheckoutBuilder
 
         if let payconf = paymentConfig {
@@ -213,7 +213,12 @@ class CheckoutOptionsViewController: UIViewController, ConfigurationManager {
             builder = MercadoPagoCheckoutBuilder(publicKey: publicKey, preferenceId: prefId)
         }
 
-        builder.setLanguage("MLA")
+        if localizedTexts {
+            let texts: [PXCustomTranslationKey : String] = [.total_to_pay: "Total cambiado", .how_to_pay: "Como deseas pagar cambiado ?"]
+            builder.setLanguage("MLA", texts)
+        } else {
+            builder.setLanguage("MLA")
+        }
         
        // guard let configs = configurations else {
        //     return builder

--- a/MercadoPagoSDKExampleSwift/View Cotrollers/ConfigurationsViewController.swift
+++ b/MercadoPagoSDKExampleSwift/View Cotrollers/ConfigurationsViewController.swift
@@ -24,6 +24,7 @@ class ConfigurationsViewController: UIViewController {
     @IBOutlet weak var viewControllerSwitch: UISwitch!
     @IBOutlet weak var payerInfoSwitch: UISwitch!
     @IBOutlet weak var maxRedeemPerUserLabel: UILabel!
+    @IBOutlet weak var localizedTextsSwitch: UISwitch!
     var delegate: ConfigurationManager?
 
     override func viewDidLoad() {
@@ -41,7 +42,7 @@ class ConfigurationsViewController: UIViewController {
     }
 
     @IBAction func applyAndConfirm(_ sender: Any) {
-        let configs = Configurations(comisiones: comisionesSwitch.isOn, descuento: descuentoSwitch.isOn, tope: topeSwitch.isOn, paymentPlugin: paymentPluginSwitch.isOn, paymentPluginViewController: viewControllerSwitch.isOn, discountNotAvailable: discountNotAvailableSwitch.isOn, maxRedeemPerUser: maxRedeemPerUserStepper.value, accountMoney: accountMoneySwitch.isOn, secondFactor: secondFactorSwitch.isOn, payerInfo: payerInfoSwitch.isOn)
+        let configs = Configurations(comisiones: comisionesSwitch.isOn, descuento: descuentoSwitch.isOn, tope: topeSwitch.isOn, paymentPlugin: paymentPluginSwitch.isOn, paymentPluginViewController: viewControllerSwitch.isOn, discountNotAvailable: discountNotAvailableSwitch.isOn, maxRedeemPerUser: maxRedeemPerUserStepper.value, accountMoney: accountMoneySwitch.isOn, secondFactor: secondFactorSwitch.isOn, payerInfo: payerInfoSwitch.isOn, localizedTexts: localizedTextsSwitch.isOn)
 
         if let delegate = delegate {
             delegate.setConfigurations(configs: configs)

--- a/MercadoPagoSDKExampleSwift/View Cotrollers/ConfigurationsViewController.xib
+++ b/MercadoPagoSDKExampleSwift/View Cotrollers/ConfigurationsViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,6 +16,7 @@
                 <outlet property="comisionesSwitch" destination="csf-l2-8Oc" id="ilN-s9-Tzw"/>
                 <outlet property="descuentoSwitch" destination="eRB-X4-oQv" id="F0m-4F-bFT"/>
                 <outlet property="discountNotAvailableSwitch" destination="gvP-a7-hhS" id="Mvt-jz-ZZe"/>
+                <outlet property="localizedTextsSwitch" destination="C3D-4L-kt1" id="FeZ-uN-ZXY"/>
                 <outlet property="maxRedeemPerUserLabel" destination="3lj-wF-Ixo" id="uOe-gX-l4b"/>
                 <outlet property="maxRedeemPerUserStepper" destination="JDR-wu-zYq" id="Smm-z0-vSC"/>
                 <outlet property="payerInfoSwitch" destination="8n7-Ii-ykq" id="LVS-7S-0NT"/>
@@ -185,6 +186,16 @@
                     <rect key="frame" x="312" y="386" width="51" height="31"/>
                     <accessibility key="accessibilityConfiguration" identifier="payer_info_switch"/>
                 </switch>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Change localized texts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hdw-2t-S8m">
+                    <rect key="frame" x="18" y="430" width="286" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="C3D-4L-kt1">
+                    <rect key="frame" x="312" y="425" width="51" height="31"/>
+                    <accessibility key="accessibilityConfiguration" identifier="localized_texts_switch"/>
+                </switch>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
@@ -192,10 +203,12 @@
                 <constraint firstItem="xrh-32-Ecp" firstAttribute="leading" secondItem="8Ws-aM-4Sf" secondAttribute="trailing" constant="8" id="0jV-u7-mr5"/>
                 <constraint firstItem="Kzy-Rm-Udr" firstAttribute="centerY" secondItem="8n7-Ii-ykq" secondAttribute="centerY" id="19i-IL-WBF"/>
                 <constraint firstItem="csf-l2-8Oc" firstAttribute="leading" secondItem="Qf7-am-hZf" secondAttribute="trailing" constant="8" id="1uJ-yF-9jB"/>
+                <constraint firstItem="Hdw-2t-S8m" firstAttribute="trailing" secondItem="Kzy-Rm-Udr" secondAttribute="trailing" id="3Ox-3D-0Ci"/>
                 <constraint firstItem="8Ws-aM-4Sf" firstAttribute="trailing" secondItem="r0T-qp-qRg" secondAttribute="trailing" id="3rH-3d-wyy"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="r0T-qp-qRg" secondAttribute="trailing" constant="71" id="5MW-Og-lzh"/>
                 <constraint firstItem="Qf7-am-hZf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="7Bg-Lv-LMn"/>
                 <constraint firstItem="L4k-WZ-aN8" firstAttribute="top" secondItem="VZi-iG-Fxk" secondAttribute="bottom" constant="8" symbolic="YES" id="7WE-Nr-VBT"/>
+                <constraint firstItem="Hdw-2t-S8m" firstAttribute="leading" secondItem="Kzy-Rm-Udr" secondAttribute="leading" id="7Xq-WP-C3m"/>
                 <constraint firstItem="eRB-X4-oQv" firstAttribute="leading" secondItem="5Pc-eE-keT" secondAttribute="trailing" constant="8" id="8wU-m0-ZRM"/>
                 <constraint firstItem="JdY-3h-ulB" firstAttribute="top" secondItem="JDR-wu-zYq" secondAttribute="bottom" constant="13" id="B0g-xn-GPp"/>
                 <constraint firstItem="hnr-31-BCz" firstAttribute="centerY" secondItem="hkR-Fh-rXi" secondAttribute="centerY" id="CiL-0c-ylg"/>
@@ -208,6 +221,7 @@
                 <constraint firstItem="hnr-31-BCz" firstAttribute="leading" secondItem="dJR-gT-Oyn" secondAttribute="leading" id="G8A-mF-cls"/>
                 <constraint firstItem="Qf7-am-hZf" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="20" id="GNC-ql-KrB"/>
                 <constraint firstItem="vXY-Uv-WUy" firstAttribute="leading" secondItem="5Pc-eE-keT" secondAttribute="leading" id="GrY-1q-scF"/>
+                <constraint firstItem="Hdw-2t-S8m" firstAttribute="top" secondItem="Kzy-Rm-Udr" secondAttribute="bottom" constant="18" id="GyL-Cp-WfQ"/>
                 <constraint firstItem="gvP-a7-hhS" firstAttribute="top" secondItem="hnr-31-BCz" secondAttribute="bottom" constant="8" symbolic="YES" id="H3J-dT-EP6"/>
                 <constraint firstItem="csf-l2-8Oc" firstAttribute="centerY" secondItem="Qf7-am-hZf" secondAttribute="centerY" id="HNK-gj-mDc"/>
                 <constraint firstItem="JDR-wu-zYq" firstAttribute="top" secondItem="gvP-a7-hhS" secondAttribute="bottom" constant="8" symbolic="YES" id="Hx1-z2-dR1"/>
@@ -244,10 +258,12 @@
                 <constraint firstItem="ei5-8p-L6c" firstAttribute="leading" secondItem="hkR-Fh-rXi" secondAttribute="leading" id="nhT-07-bKR"/>
                 <constraint firstItem="eRB-X4-oQv" firstAttribute="leading" secondItem="csf-l2-8Oc" secondAttribute="leading" id="nuU-Xu-XBa"/>
                 <constraint firstItem="hnr-31-BCz" firstAttribute="top" secondItem="dJR-gT-Oyn" secondAttribute="bottom" constant="8" id="ooi-VX-DcH"/>
+                <constraint firstItem="Hdw-2t-S8m" firstAttribute="centerY" secondItem="C3D-4L-kt1" secondAttribute="centerY" id="qcY-id-wJT"/>
                 <constraint firstItem="eRB-X4-oQv" firstAttribute="centerY" secondItem="5Pc-eE-keT" secondAttribute="centerY" id="rN7-KO-dsq"/>
                 <constraint firstItem="hkR-Fh-rXi" firstAttribute="top" secondItem="vXY-Uv-WUy" secondAttribute="bottom" constant="18" id="sPv-4Z-8Yu"/>
                 <constraint firstItem="xrh-32-Ecp" firstAttribute="top" secondItem="L4k-WZ-aN8" secondAttribute="bottom" constant="8" symbolic="YES" id="tZZ-lP-Qk8"/>
                 <constraint firstItem="L4k-WZ-aN8" firstAttribute="leading" secondItem="g4u-6c-ldg" secondAttribute="trailing" constant="8" id="tnR-fG-5MG"/>
+                <constraint firstItem="C3D-4L-kt1" firstAttribute="leading" secondItem="Hdw-2t-S8m" secondAttribute="trailing" constant="8" symbolic="YES" id="tvE-hL-8gu"/>
                 <constraint firstItem="csf-l2-8Oc" firstAttribute="leading" secondItem="Qf7-am-hZf" secondAttribute="trailing" constant="8" id="uae-O0-k70"/>
                 <constraint firstItem="Dkn-CY-kWJ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="11" id="vjR-To-e0c"/>
                 <constraint firstItem="hnr-31-BCz" firstAttribute="leading" secondItem="hkR-Fh-rXi" secondAttribute="trailing" constant="8" id="wd8-t4-aM6"/>

--- a/MercadoPagoSDKExampleSwift/View Cotrollers/ExamplePaymentProcessorViewController.swift
+++ b/MercadoPagoSDKExampleSwift/View Cotrollers/ExamplePaymentProcessorViewController.swift
@@ -10,23 +10,10 @@ import UIKit
 
 class ExamplePaymentProcessorViewController: UIViewController {
     var handler : PXPaymentProcessorNavigationHandler?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
-
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
     @IBAction func continueToCongrats(_ sender: Any) {
         guard let handler = handler else {

--- a/MercadoPagoSDKExampleSwiftTests/MercadoPagoSDKExampleSwiftTests.swift
+++ b/MercadoPagoSDKExampleSwiftTests/MercadoPagoSDKExampleSwiftTests.swift
@@ -10,27 +10,26 @@ import XCTest
 @testable import MercadoPagoSDKExampleSwift
 
 class MercadoPagoSDKExampleSwiftTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testExample() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-    
+
     func testPerformanceExample() {
         // This is an example of a performance test case.
         self.measure {
             // Put the code you want to measure the time of here.
         }
     }
-    
 }

--- a/MercadoPagoSDKExampleSwiftUITests/ScreenObject/BaseScreen.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/ScreenObject/BaseScreen.swift
@@ -81,6 +81,12 @@ public extension BaseScreen {
     func element(_ text: String) -> XCUIElement {
         return XCUIApplication().staticTexts[text].firstMatch
     }
+    func labelContains(_ text: String) -> XCUIElement {
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", text)
+        let result = XCUIApplication().staticTexts.containing(predicate)
+        let element = XCUIApplication().staticTexts[result.element.label]
+        return element
+    }
     func otherElement(_ text: String) -> XCUIElement {
         return XCUIApplication().otherElements[text].firstMatch
     }

--- a/MercadoPagoSDKExampleSwiftUITests/ScreenObject/ConfigurationScreen.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/ScreenObject/ConfigurationScreen.swift
@@ -16,6 +16,7 @@ public class ConfigurationScreen: BaseScreen {
     private lazy var accountMoneySwitch = switchElement("account_money_switch")
     private lazy var secondFactorSwitch = switchElement("second_factor_switch")
     private lazy var payerInfoSwitch = switchElement("payer_info_switch")
+    private lazy var localizedTextsSwitch = switchElement("localized_texts_switch")
     private lazy var paymentPluginSwitch = switchElement("payment_plugin_switch")
     private lazy var discountNotAvailableSwitch = switchElement("discount_not_available_switch")
     private lazy var maxRedeemPerUserStepper = stepper("max_redeem_per_user_stepper")
@@ -64,6 +65,11 @@ public class ConfigurationScreen: BaseScreen {
 
     func changePayerInfoSwitch() -> ConfigurationScreen {
         payerInfoSwitch.tap()
+        return self
+    }
+
+    func changeLocalizedTextsSwitch() -> ConfigurationScreen {
+        localizedTextsSwitch.tap()
         return self
     }
 

--- a/MercadoPagoSDKExampleSwiftUITests/ScreenObject/CongratsScreen.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/ScreenObject/CongratsScreen.swift
@@ -15,7 +15,7 @@ public class CongratsScreen: BaseScreen {
     override open func waitForElements() {
        // let instructionsFooterButton = element("Cancelar pago")
        // waitFor(element: instructionsFooterButton)
-        waitForAnyCongrats()
+        let _ = waitForAnyCongrats()
     }
 //
     func waitForAnyCongrats() -> CongratsScreen {

--- a/MercadoPagoSDKExampleSwiftUITests/ScreenObject/MainGroupScreen.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/ScreenObject/MainGroupScreen.swift
@@ -10,11 +10,11 @@ import XCTest
 
 public class MainGroupScreen: BaseScreen {
 
-    lazy var vaultView = element("¿Cómo quieres pagar?")
+    lazy var vaultView = otherElement("paymentOptionImageContainer")
     lazy var cardButton = cell("Nueva tarjeta")
     lazy var cashButton = cell("Pago en efectivo")
     lazy var boletoButton = cell("Boleto Bancário")
-    lazy var internetBoletoButton = cell("Internet Banking")
+    lazy var boletoPecButton = cell("Pagamento na lotética sem boleto")
     lazy var floatingRow = element("floating_row_main_value_label")
 
     override open func waitForElements() {
@@ -51,19 +51,30 @@ public class MainGroupScreen: BaseScreen {
         return ReviewScreen()
     }
 
-    func tapBoletoOption() -> MainGroupScreen {
+    func tapBoletoOption() -> PayerInfoScreen {
         boletoButton.tap()
-        return MainGroupScreen()
-    }
-
-    func tapBoletoInternetBanking() -> PayerInfoScreen {
-        internetBoletoButton.tap()
         return PayerInfoScreen()
     }
 
-    func tapBoletoInternetBankingForReview() -> ReviewScreen {
-        internetBoletoButton.tap()
+    func tapBoletoOptionForReview() -> ReviewScreen {
+        boletoButton.tap()
         return ReviewScreen()
+    }
+
+    func tapBoletoPec() -> PayerInfoScreen {
+        boletoPecButton.tap()
+        return PayerInfoScreen()
+    }
+
+    func tapBoletoPecForReview() -> ReviewScreen {
+        boletoPecButton.tap()
+        return ReviewScreen()
+    }
+
+    func findText(_ text: String) -> MainGroupScreen {
+        let element = self.element(text)
+        waitFor(element: element)
+        return MainGroupScreen()
     }
 }
 

--- a/MercadoPagoSDKExampleSwiftUITests/ScreenObject/MainGroupScreen.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/ScreenObject/MainGroupScreen.swift
@@ -14,7 +14,7 @@ public class MainGroupScreen: BaseScreen {
     lazy var cardButton = cell("Nueva tarjeta")
     lazy var cashButton = cell("Pago en efectivo")
     lazy var boletoButton = cell("Boleto Bancário")
-    lazy var boletoPecButton = cell("Pagamento na lotética sem boleto")
+    lazy var boletoPecButton = cell("Pagamento na lotérica sem boleto")
     lazy var floatingRow = element("floating_row_main_value_label")
 
     override open func waitForElements() {

--- a/MercadoPagoSDKExampleSwiftUITests/ScreenObject/ReviewScreen.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/ScreenObject/ReviewScreen.swift
@@ -71,4 +71,10 @@ public class ReviewScreen: BaseScreen {
         changePayerInfoButton.tap()
         return PayerInfoScreen()
     }
+
+    func findLabelContainsText(_ text: String) -> ReviewScreen {
+        let element = self.labelContains(text)
+        waitFor(element: element)
+        return ReviewScreen()
+    }
 }

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/AccountMoneyPluginTest.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/AccountMoneyPluginTest.swift
@@ -22,7 +22,7 @@ class AccountMoneyPluginTest: XCTestCase {
     }
     
     func test_account_money_with_second_factor() {
-        MainScreen()
+        let _ = MainScreen()
             .tapConfigurationsButton()
             .changeAccountMoneySwitch()
             .changeSecondFactorSwitch()

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/AddCardTests.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/AddCardTests.swift
@@ -9,12 +9,12 @@
 import XCTest
 
 class AddCardTests: XCTestCase {
-        
+
     override func setUp() {
         super.setUp()
-        
+
         // Put setup code here. This method is called before the invocation of each test method in the class.
-        
+
         // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
         // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
@@ -22,12 +22,12 @@ class AddCardTests: XCTestCase {
 
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testAddVisaCard() {
         _ = MainScreen()
             .fillAccessToken("APP_USR-1505-080815-c6ea450de1bf828e39add499237d727f-312667294")
@@ -38,7 +38,7 @@ class AddCardTests: XCTestCase {
             .completeCVVAndContinue("123")
             .completeNumberAndContinueToCongrats("12345678")
     }
-    
+
     func testAddAmexCard() {
         _ = MainScreen()
             .fillAccessToken("APP_USR-1505-080815-c6ea450de1bf828e39add499237d727f-312667294")
@@ -49,7 +49,7 @@ class AddCardTests: XCTestCase {
             .completeCVVAndContinue("1234")
             .completeNumberAndContinueToCongrats("12345678")
     }
-    
+
     func testMasterDebitCard() {
         _ = MainScreen()
             .fillAccessToken("APP_USR-1945000207238192-100316-bfa3a266fb63c50143034e0bef59c254-290714514")
@@ -59,7 +59,7 @@ class AddCardTests: XCTestCase {
             .completeExpirationDateAndContinue("1225")
             .completeCVVAndContinueToCongrats("123")
     }
-    
+
     func testAddAmexNoID() {
         //AT de MLM
         _ = MainScreen()
@@ -70,7 +70,7 @@ class AddCardTests: XCTestCase {
             .completeExpirationDateAndContinue("1225")
             .completeCVVAndContinueToCongrats("1234")
     }
-    
+
     func testAddHipercardMLB() {
         _ = MainScreen()
             .fillAccessToken("APP_USR-1945000207238192-100317-a0ae23e7c7b588d4b735dd070725b3ac-242964413")
@@ -81,5 +81,4 @@ class AddCardTests: XCTestCase {
             .completeCVVAndContinue("123")
             .completeNumberAndContinueToCongrats("63538416397")
     }
-    
 }

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/ChargesTest.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/ChargesTest.swift
@@ -16,14 +16,13 @@ class ChargesTest: XCTestCase {
         continueAfterFailure = false
         XCUIApplication().launch()
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func test_flujo_con_comision_para_creditcard(){
-        
-        MainScreen()
+        let _ = MainScreen()
             .tapConfigurationsButton()
             .changeComisionesSwitch()
             .tapApplyConfigurationsButton()
@@ -41,8 +40,5 @@ class ChargesTest: XCTestCase {
             .selectIssuerOptionToPayerCostScreenAtRow(1)
             .selectPayerCostOptionAtRow(2)
             .tapPayButtonForAnyCongrats()
-        
-        
     }
-
 }

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXBoletoTest.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXBoletoTest.swift
@@ -130,4 +130,40 @@ class PXBoletoTest: XCTestCase {
             .completeLastNameAndContinueToReview("PEREZ")
             .tapPayButtonForAnyCongrats()
     }
+
+    func test_boleto_accreditation_time_pref_cerrada() {
+        let _ = MainScreen()
+            .tapClearButton()
+            .tapConfigurationsButton()
+            .changePaymentPluginSwitch()
+            .changePayerInfoSwitch()
+            .tapApplyConfigurationsButton()
+            .fillPublicKey("APP_USR-f3f035a2-d343-4a6f-bd3b-fc3c3cb72416")
+            .fillPreferenceId("245099733-8771f469-d68e-4863-b8cb-9402e22c6bb2")
+            .tapCheckoutOption()
+            .tapBoletoOptionForReview()
+            .tapChangePayerInfo()
+            .completeNumberAndContinueToPayer("05487765634")
+            .completeNameAndContinueToPayer("JUAN")
+            .completeLastNameAndContinueToReview("PEREZ")
+            .findLabelContainsText("Se acreditará en 1 día hábil")
+    }
+
+    func test_pec_accreditation_time_pref_cerrada() {
+        let _ = MainScreen()
+            .tapClearButton()
+            .tapConfigurationsButton()
+            .changePaymentPluginSwitch()
+            .changePayerInfoSwitch()
+            .tapApplyConfigurationsButton()
+            .fillPublicKey("APP_USR-f3f035a2-d343-4a6f-bd3b-fc3c3cb72416")
+            .fillPreferenceId("245099733-8771f469-d68e-4863-b8cb-9402e22c6bb2")
+            .tapCheckoutOption()
+            .tapBoletoPecForReview()
+            .tapChangePayerInfo()
+            .completeNumberAndContinueToPayer("05487765634")
+            .completeNameAndContinueToPayer("JUAN")
+            .completeLastNameAndContinueToReview("PEREZ")
+            .findLabelContainsText("Se acreditará en 1 hora")
+    }
 }

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXBoletoTest.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXBoletoTest.swift
@@ -30,7 +30,6 @@ class PXBoletoTest: XCTestCase {
             .fillAccessToken("APP_USR-1505-101710-2aa28f80031d35d3fc866e17765bde43-347997394")
             .tapCheckoutOption()
             .tapBoletoOption()
-            .tapBoletoInternetBanking()
             .completeNumberAndContinueToPayer("05487765634")
             .completeNameAndContinueToPayer("JUAN")
             .completeLastNameAndContinueToReview("PEREZ")
@@ -47,8 +46,7 @@ class PXBoletoTest: XCTestCase {
             .fillPublicKey("APP_USR-0c49ceb6-3cf7-4be9-b59d-f1f76671af68")
             .fillAccessToken("APP_USR-1505-101710-2aa28f80031d35d3fc866e17765bde43-347997394")
             .tapCheckoutOption()
-            .tapBoletoOption()
-            .tapBoletoInternetBankingForReview()
+            .tapBoletoOptionForReview()
             .tapPayButtonForAnyCongrats()
     }
 
@@ -62,12 +60,25 @@ class PXBoletoTest: XCTestCase {
             .fillPublicKey("APP_USR-0c49ceb6-3cf7-4be9-b59d-f1f76671af68")
             .fillAccessToken("APP_USR-1505-101710-2aa28f80031d35d3fc866e17765bde43-347997394")
             .tapCheckoutOption()
-            .tapBoletoOption()
-            .tapBoletoInternetBankingForReview()
+            .tapBoletoOptionForReview()
             .tapChangePayerInfo()
             .completeNumberAndContinueToPayer("05487765634")
             .completeNameAndContinueToPayer("JUAN")
             .completeLastNameAndContinueToReview("PEREZ")
             .tapPayButtonForAnyCongrats()
+    }
+
+    func test_boleto_cambio_textos() {
+        let _ = MainScreen()
+            .tapClearButton()
+            .tapConfigurationsButton()
+            .changePaymentPluginSwitch()
+            .changeLocalizedTextsSwitch()
+            .tapApplyConfigurationsButton()
+            .fillPublicKey("APP_USR-0c49ceb6-3cf7-4be9-b59d-f1f76671af68")
+            .fillAccessToken("APP_USR-1505-101710-2aa28f80031d35d3fc866e17765bde43-347997394")
+            .tapCheckoutOption()
+            .findText("Como deseas pagar cambiado ?")
+            .findText("Total cambiado")
     }
 }

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXBoletoTest.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXBoletoTest.swift
@@ -81,4 +81,53 @@ class PXBoletoTest: XCTestCase {
             .findText("Como deseas pagar cambiado ?")
             .findText("Total cambiado")
     }
+
+    // Mark: Pref cerradas
+    func test_boleto_pref_cerrada() {
+        let _ = MainScreen()
+            .tapClearButton()
+            .tapConfigurationsButton()
+            .changePaymentPluginSwitch()
+            .tapApplyConfigurationsButton()
+            .fillPublicKey("APP_USR-f3f035a2-d343-4a6f-bd3b-fc3c3cb72416")
+            .fillPreferenceId("245099733-8771f469-d68e-4863-b8cb-9402e22c6bb2")
+            .tapCheckoutOption()
+            .tapBoletoOption()
+            .completeNumberAndContinueToPayer("05487765634")
+            .completeNameAndContinueToPayer("JUAN")
+            .completeLastNameAndContinueToReview("PEREZ")
+            .tapPayButtonForAnyCongrats()
+    }
+    
+    func test_boleto_con_payer_pref_cerrada() {
+        let _ = MainScreen()
+            .tapClearButton()
+            .tapConfigurationsButton()
+            .changePaymentPluginSwitch()
+            .changePayerInfoSwitch()
+            .tapApplyConfigurationsButton()
+            .fillPublicKey("APP_USR-f3f035a2-d343-4a6f-bd3b-fc3c3cb72416")
+            .fillPreferenceId("245099733-8771f469-d68e-4863-b8cb-9402e22c6bb2")
+            .tapCheckoutOption()
+            .tapBoletoOptionForReview()
+            .tapPayButtonForAnyCongrats()
+    }
+    
+    func test_boleto_modificar_payer_pref_cerrada() {
+        let _ = MainScreen()
+            .tapClearButton()
+            .tapConfigurationsButton()
+            .changePaymentPluginSwitch()
+            .changePayerInfoSwitch()
+            .tapApplyConfigurationsButton()
+            .fillPublicKey("APP_USR-f3f035a2-d343-4a6f-bd3b-fc3c3cb72416")
+            .fillPreferenceId("245099733-8771f469-d68e-4863-b8cb-9402e22c6bb2")
+            .tapCheckoutOption()
+            .tapBoletoOptionForReview()
+            .tapChangePayerInfo()
+            .completeNumberAndContinueToPayer("05487765634")
+            .completeNameAndContinueToPayer("JUAN")
+            .completeLastNameAndContinueToReview("PEREZ")
+            .tapPayButtonForAnyCongrats()
+    }
 }

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXDiscountUITest.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXDiscountUITest.swift
@@ -21,7 +21,7 @@ class PXDiscountUITest: XCTestCase {
     }
 
     func test_descuento_integrador_con_tope() { //Tarjeta MASTER con cuotas SIN INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-b8925182-e1bf-4c0e-bc38-1d893a19ab45")
             .fillPreferenceId("241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3")
@@ -74,7 +74,7 @@ class PXDiscountUITest: XCTestCase {
     }
 
     func test_descuento_directo_con_payment_plugin() { //Tarjeta MASTER con cuotas SIN INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-b8925182-e1bf-4c0e-bc38-1d893a19ab45")
             .fillPreferenceId("241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3")
@@ -110,7 +110,7 @@ class PXDiscountUITest: XCTestCase {
     }
 
     func test_descuento_directo_con_tope() { //Tarjeta MASTER con cuotas SIN INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-b8925182-e1bf-4c0e-bc38-1d893a19ab45")
             .fillPreferenceId("241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3")
@@ -157,7 +157,7 @@ class PXDiscountUITest: XCTestCase {
     }
 
     func test_descuento_no_disponible_por_budget_agotado() { //Tarjeta MASTER con cuotas SIN INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-b8925182-e1bf-4c0e-bc38-1d893a19ab45")
             .fillPreferenceId("241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3")
@@ -217,7 +217,7 @@ class PXDiscountUITest: XCTestCase {
     }
 
     func test_descuento_one_shot() { //Tarjeta MASTER con cuotas SIN INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-b8925182-e1bf-4c0e-bc38-1d893a19ab45")
             .fillPreferenceId("241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3")
@@ -277,7 +277,7 @@ class PXDiscountUITest: XCTestCase {
     }
 
     func test_descuento_multiple_redeem_per_user() { //Tarjeta MASTER con cuotas SIN INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-b8925182-e1bf-4c0e-bc38-1d893a19ab45")
             .fillPreferenceId("241261700-459d4126-903c-4bad-bc05-82e5f13fa7d3")

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXUITests.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/PXUITests.swift
@@ -20,7 +20,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE1_1() { //Tarjeta MASTER con cuotas SIN INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-648a260d-6fd9-4ad7-9284-90f22262c18d")
             .fillPreferenceId("243966003-d0be0be0-6fd8-4769-bf2f-7f2d979655f5")
@@ -38,7 +38,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE1_2() { //Tarjeta VISA con cuotas CON INTERES
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-648a260d-6fd9-4ad7-9284-90f22262c18d")
             .fillPreferenceId("243966003-d0be0be0-6fd8-4769-bf2f-7f2d979655f5")
@@ -55,7 +55,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE1_3() { //Tarjeta AMEX en una sola cuota
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-648a260d-6fd9-4ad7-9284-90f22262c18d")
             .fillPreferenceId("243966003-d0be0be0-6fd8-4769-bf2f-7f2d979655f5")
@@ -72,7 +72,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE1_4() { //Tarjeta MAESTRO
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-648a260d-6fd9-4ad7-9284-90f22262c18d")
             .fillPreferenceId("243966003-d0be0be0-6fd8-4769-bf2f-7f2d979655f5")
@@ -88,7 +88,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE1_5() { //Tarjeta VISA DEBITO
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-648a260d-6fd9-4ad7-9284-90f22262c18d")
             .fillPreferenceId("243966003-d0be0be0-6fd8-4769-bf2f-7f2d979655f5")
@@ -104,7 +104,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE3() {
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-0d933ff3-b803-4999-a211-8b3c7d5c7c03")
             .fillPreferenceId("243966003-faedce8f-ee83-40a7-b8e6-bba34928383d")
@@ -115,7 +115,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE5() {
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-0d933ff3-b803-4999-a211-8b3c7d5c7c03")
             .fillPreferenceId("243966003-0e1df452-28e3-4d72-8b69-a71123b8a626")
@@ -132,7 +132,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE6() {
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-0d933ff3-b803-4999-a211-8b3c7d5c7c03")
             .fillPreferenceId("243966003-bb8f7422-39c1-4337-81dd-60a88eb787df")
@@ -148,7 +148,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE7_1() {
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-0d933ff3-b803-4999-a211-8b3c7d5c7c03")
             .fillPreferenceId("243966003-55f883b7-2cfb-4266-8001-11e081a45797")
@@ -166,7 +166,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE7_2() {
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-0d933ff3-b803-4999-a211-8b3c7d5c7c03")
             .fillPreferenceId("243966003-55f883b7-2cfb-4266-8001-11e081a45797")
@@ -178,7 +178,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE8() { //Hacer backs payment_type: Crédito
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("TEST-e4bdd1cf-bcb2-43f7-b565-ed4c9ea25be7")
             .fillPreferenceId("243966003-bb8f7422-39c1-4337-81dd-60a88eb787df")
@@ -203,7 +203,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE9() { //Hacer backs sin exclusiones
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("TEST-c6d9b1f9-71ff-4e05-9327-3c62468a23ee")
             .fillPreferenceId("243962506-e9464aff-30dd-43e0-a6fa-37e3a54b884c")
@@ -230,7 +230,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE10() {
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("TEST-c6d9b1f9-71ff-4e05-9327-3c62468a23ee")
             .fillPreferenceId("243962506-465d2dc6-f83b-4090-be64-8374196a3ab3")
@@ -251,7 +251,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE11_1() { //Verificar CFT Tarjeta VISA con Interes
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("TEST-c6d9b1f9-71ff-4e05-9327-3c62468a23ee")
             .fillPreferenceId("243962506-76cc070f-4678-4eb2-9ada-1605e95986b5")
@@ -270,7 +270,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE11_2() { //Verificar CFT Tarjeta MASTER sin Interes
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("TEST-c6d9b1f9-71ff-4e05-9327-3c62468a23ee")
             .fillPreferenceId("243962506-76cc070f-4678-4eb2-9ada-1605e95986b5")
@@ -289,7 +289,7 @@ class PXFlowUITests: XCTestCase {
     }
 
     func test_REGRESSION_ETE12() {
-        MainScreen()
+        let _ = MainScreen()
             .tapClearButton()
             .fillPublicKey("APP_USR-2681ea61-10af-4bf6-a73d-e426d6b07e2c")
             .fillPreferenceId("243962506-76f3ae80-28de-4c8a-94a5-dad78ef8b4c4")

--- a/MercadoPagoSDKExampleSwiftUITests/Test Flow/PluginProcessorTest.swift
+++ b/MercadoPagoSDKExampleSwiftUITests/Test Flow/PluginProcessorTest.swift
@@ -10,18 +10,19 @@ import XCTest
 import MercadoPagoSDKV4
 
 class PluginProcessorTest: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
         XCUIApplication().launch()
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
+
     func test_payment_processor_without_view_controller() {
-        MainScreen()
+        let _ = MainScreen()
             .tapConfigurationsButton()
             .changePluginViewControllerSwitch()
             .tapApplyConfigurationsButton()
@@ -33,8 +34,9 @@ class PluginProcessorTest: XCTestCase {
             .tapRapipagoOption()
             .tapPayButtonForAnyCongrats()
     }
+
     func test_payment_processor_with_view_controller() {
-        MainScreen()
+        let _ = MainScreen()
             .tapConfigurationsButton()
             .changePluginViewControllerSwitch()
             .changePaymentPluginSwitch()
@@ -48,5 +50,4 @@ class PluginProcessorTest: XCTestCase {
             .tapPayButtonForPluginProcessorViewController()
             .continueCheckoutToAnyCongrats()
     }
-    
 }

--- a/Podfile
+++ b/Podfile
@@ -9,8 +9,8 @@ target 'MercadoPagoSDKExampleSwift' do
 
   # //:git => 'git@github.com:mercadopago/px-ios.git', :branch => 'add_card_flow'
   # Pods for MercadoPagoSDKExampleSwift
-  pod 'MercadoPagoSDKV4/ESC'
-  pod 'PXAccountMoneyPlugin', '4.0.0'
+  pod 'MercadoPagoSDKV4/ESC', :git => 'git@github.com:mercadopago/px-ios.git', :branch => 'develop'
+  pod 'PXAccountMoneyPlugin', '4.0.2'
 
   target 'MercadoPagoSDKExampleSwiftTests' do
     inherit! :search_paths


### PR DESCRIPTION
Se agregan test para cambio de texto en header y footer de la pantalla de selección de métodos de pago

Se agregan test de boleto con pref cerradas

Se agrega test del cambio de accreditation time en boleto MLB

Se agrega método para buscar un label que "**contenga**" un texto

Se eliminan warnings